### PR TITLE
4 implement class

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,8 @@
         "eamodio.gitlens",
         "github.vscode-pull-request-github",
         "github.vscode-github-actions",
-        "shardulm94.trailing-spaces"
+        "shardulm94.trailing-spaces",
+        "gruntfuggly.todo-tree"
       ]
     }
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,8 @@
     "stdio.h": "c",
     "a_internal.h": "c",
     "features.h": "c",
-    "string.h": "c"
+    "string.h": "c",
+    "stddef.h": "c"
   },
   "C_Cpp.codeAnalysis.clangTidy.enabled": true,
   "C_Cpp.codeAnalysis.runAutomatically": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,9 @@
     "a_internal.h": "c",
     "features.h": "c",
     "string.h": "c",
-    "stddef.h": "c"
+    "stddef.h": "c",
+    "unistd.h": "c",
+    "class.h": "c"
   },
   "C_Cpp.codeAnalysis.clangTidy.enabled": true,
   "C_Cpp.codeAnalysis.runAutomatically": true,

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ $(ODIR)%.o: $(SDIR)%.c $(DEPS)
 	@if grep -qE $(TEST-REGEX) $<; then \
 		printf "# 1 \"$<\"\n" | \
 		cat - $< | \
-		cat - <(printf "\n\nint main(__attribute__((unused)) int argc, __attribute__((unused)) char* argv[]) {\n  int i = 0, err = 0;\n") | \
-		cat - <(grep -onE $(TEST-REGEX) $< | awk -F[\(\)' ':] '{print "  printf(\"%3d RUNNING: %s:%-4d \\x1B[36m" $$8 "()\\x1B[0m\\n\", ++i, __FILE__, " $$1 ");\n  err |= " $$8 "(argc, argv);"}') | \
+		cat - <(printf "\n\n#include <stdio.h>\nint main(__attribute__((unused)) int argc, __attribute__((unused)) char* argv[]) {\n  int i = 0, err = 0;\n") | \
+		cat - <(grep -onE $(TEST-REGEX) $< | awk -F[\(\)' ':] '{print "  printf(\"%3d: %s:%-4d \\x1B[36m" $$8 "()\\x1B[0m\\n\", ++i, __FILE__, " $$1 ");\n  err |= " $$8 "(argc, argv);"}') | \
 		cat - <(printf "  return err;\n}\n") | \
 		sed -e 's/__attribute__((test)) //g' | \
 		$(CC) -c -o $@ -xc - $(CFLAGS) $$(find src/ -type d | sed -e 's/^/-I/'); \

--- a/src/assert/public/assert.h
+++ b/src/assert/public/assert.h
@@ -97,7 +97,7 @@
  * @param s Error string
  */
 #define assert_notequal(l, v1, v2, s) ({ \
-  if (v1 != v2) { \
+  if (v1 == v2) { \
     uint8_t _a_temp_ = __assert_fail( \
       l, \
       s, \

--- a/src/class/private/c_base.c
+++ b/src/class/private/c_base.c
@@ -1,0 +1,74 @@
+#include <stddef.h>
+
+#include "class.h"
+
+/**
+ * @brief Returns the name of specific class
+ *
+ * @param c The class
+ * @return const char* The name of the class
+ */
+const char* class_name(const class_t* c) {
+  return c->name;
+}
+
+/**
+ * @brief Destroys an object of this class type
+ *
+ * @param c The class
+ * @param self the object to destroy
+ */
+void class_destroy(const class_t* c, void* self) {
+  if (c->destroy != NULL)
+    c->destroy(self);
+}
+
+/**
+ * @brief Returns a representation of an object of this class type
+ *
+ * @param c The class
+ * @param self the object to represent
+ * @return rope_t* Representation of the object
+ *
+ * @note The returned rope must be destroyed after use
+ * @note Returns NULL if no representation function is defined
+ */
+rope_t* class_repr(const class_t* c, const void* self) {
+  if (c->repr == NULL)
+    return NULL;
+  return c->repr(self);
+}
+
+/**
+ * @brief Returns a hash of an object of this class type
+ *
+ * @param c The class
+ * @param self The object to hash
+ * @return uint64_t The hash of the object
+ *
+ * @note Returns pointer hash if no hashing function is defined
+ */
+uint64_t class_hash(const class_t* c, const void* self) {
+  if (c->hash == NULL)
+    return class_hash(ptr_class, self);
+  return c->hash(self);
+}
+
+/**
+ * @brief Returns the comparison of two object of this class type
+ *
+ * @param c The class
+ * @param self The first object to compare
+ * @param other The second object to compare
+ * @return int
+ *    >0: self > other
+ *    <0: self < other
+ *    =0: self = other
+ *
+ * @note Returns pointer comparison if no comparison function is defined
+ */
+int class_cmp(const class_t* c, const void* self, const void* other) {
+  if (c->hash == NULL)
+    class_cmp(ptr_class, self, other);
+  return c->cmp(self, other);
+}

--- a/src/class/private/c_ptr.c
+++ b/src/class/private/c_ptr.c
@@ -1,0 +1,52 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+
+#include "class.h"
+
+/**
+ * @brief Return a representation of this pointer in a rope_t
+ *
+ * @param p The pointer
+ * @return rope_t* The representation of this pointer
+ */
+rope_t* ptr_repr(const void* p) {
+  char* str = (char*)malloc(
+    sizeof(long long) * 2 - __builtin_clzll((ptrdiff_t)p) / 4 + 3 * sizeof(*str)
+  );
+  sprintf(str, "%p", p);
+  rope_t* r = rope_create_with(str);
+  free(str);
+  return r;
+}
+
+/**
+ * @brief Return a hash of this pointer
+ *
+ * @param p The pointer
+ * @return uint64_t The hash of this pointer
+ */
+uint64_t ptr_hash(const void* p) {
+  return (uint64_t)p;
+}
+
+/**
+ * @brief Compare two pointers
+ *
+ * @param p1 The first pointer to compare
+ * @param p2 The second pointer to compare
+ * @return int p1 - p2
+ */
+int ptr_cmp(const void* p1, const void* p2) {
+  return p1 - p2;
+}
+
+/// @brief Pointer class
+const class_t* ptr_class = &(class_t){
+  .name = "ptr",
+  .destroy = NULL,
+  .repr = ptr_repr,
+  .hash = ptr_hash,
+  .cmp = ptr_cmp
+};

--- a/src/class/private/c_ptr.c
+++ b/src/class/private/c_ptr.c
@@ -28,7 +28,7 @@ rope_t* ptr_repr(const void* p) {
  * @return uint64_t The hash of this pointer
  */
 uint64_t ptr_hash(const void* p) {
-  return (uint64_t)p;
+  return (uint64_t)(ptrdiff_t)p;
 }
 
 /**

--- a/src/class/private/c_str.c
+++ b/src/class/private/c_str.c
@@ -1,0 +1,41 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+
+#include "class.h"
+
+/**
+ * @brief Return a representation of this string in a rope_t
+ *
+ * @param s The string
+ * @return rope_t* The representation of this string
+ */
+rope_t* str_repr(const void* s) {
+  rope_t* r = rope_create_with(s);
+  return r;
+}
+
+/**
+ * @brief Return a hash of this string using djb2
+ *
+ * @param s The string
+ * @return uint64_t The hash of this string
+ */
+uint64_t str_hash(const void* s) {
+  uint64_t hash = 5381;
+  char c;
+  while ((c = *(const char*)s++))
+    hash = ((hash << 5) + hash) + c;
+
+  return hash;
+}
+
+/// @brief String class
+const class_t* str_class = &(class_t){
+  .name = "str",
+  .destroy = free,
+  .repr = str_repr,
+  .hash = str_hash,
+  .cmp = (int (*const)(const void *, const void *))strcmp
+};

--- a/src/class/public/class.h
+++ b/src/class/public/class.h
@@ -1,0 +1,39 @@
+/**
+ * @file class.h
+ * @author Isaac Denning (117934828+idenning2003@users.noreply.github.com)
+ * @brief This describes a few function pointers that can be used for many
+ * structures to interact with eachother generically.
+ * @date 2024-07-11
+ */
+
+#ifndef CLASS_H
+#define CLASS_H
+
+#include <stdint.h>
+
+#include "rope.h"
+
+/// @brief Methods of a class
+typedef struct Class {
+  /// @brief The name of this class
+  const char* name;
+  /// @brief Destroys an object of this class type
+  void (*const destroy)(void*);
+  /// @brief Returns the name of specific class
+  rope_t* (*const repr)(const void*);
+  /// @brief Returns a hash of an object of this class type
+  uint64_t (*const hash)(const void*);
+  /// @brief Returns the comparison of two object of this class type
+  int (*const cmp)(const void*, const void*);
+} class_t;
+
+extern const class_t* ptr_class;
+extern const class_t* str_class;
+
+void class_destroy(const class_t*, void*);
+const char* class_name(const class_t*);
+rope_t* class_repr(const class_t*, const void*);
+uint64_t class_hash(const class_t*, const void*);
+int class_cmp(const class_t*, const void*, const void*);
+
+#endif

--- a/src/class/test/class_call_test.c
+++ b/src/class/test/class_call_test.c
@@ -1,0 +1,97 @@
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "assert.h"
+#include "class.h"
+
+bool is_class_destroy_call_test_passed = false;
+void class_destroy_call_test_func(void*) {
+  is_class_destroy_call_test_passed = true;
+}
+
+bool is_class_repr_call_test_passed = false;
+rope_t* class_repr_call_test_func(const void*) {
+  is_class_repr_call_test_passed = true;
+  return NULL;
+}
+
+bool is_class_hash_call_test_passed = false;
+uint64_t class_hash_call_test_func(const void*) {
+  is_class_hash_call_test_passed = true;
+  return 0;
+}
+
+bool is_class_cmp_call_test_passed = false;
+int class_cmp_call_test_func(const void*, const void*) {
+  is_class_cmp_call_test_passed = true;
+  return 0;
+}
+
+const class_t* class_func_test = &(class_t){
+  .name = "func_test",
+  .destroy = class_destroy_call_test_func,
+  .repr = class_repr_call_test_func,
+  .hash = class_hash_call_test_func,
+  .cmp = class_cmp_call_test_func
+};
+
+__attribute__((test)) uint8_t class_call_destroy_test() {
+  assert_false(
+    ERROR,
+    is_class_destroy_call_test_passed,
+    "Not propperly set up."
+  );
+  class_destroy(class_func_test, NULL);
+  assert_true(
+    ERROR,
+    is_class_destroy_call_test_passed,
+    "destroy function not called."
+  );
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_call_repr_test() {
+  assert_false(
+    ERROR,
+    is_class_repr_call_test_passed,
+    "Not propperly set up."
+  );
+  class_repr(class_func_test, NULL);
+  assert_true(
+    ERROR,
+    is_class_repr_call_test_passed,
+    "repr function not called."
+  );
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_call_hash_test() {
+  assert_false(
+    ERROR,
+    is_class_hash_call_test_passed,
+    "Not propperly set up."
+  );
+  class_hash(class_func_test, NULL);
+  assert_true(
+    ERROR,
+    is_class_hash_call_test_passed,
+    "hash function not called."
+  );
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_call_cmp_test() {
+  assert_false(
+    ERROR,
+    is_class_cmp_call_test_passed,
+    "Not propperly set up."
+  );
+  class_cmp(class_func_test, NULL, NULL);
+  assert_true(
+    ERROR,
+    is_class_cmp_call_test_passed,
+    "cmp function not called."
+  );
+  return EXIT_SUCCESS;
+}

--- a/src/class/test/class_ptr_test.c
+++ b/src/class/test/class_ptr_test.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "assert.h"
+#include "class.h"
+
+__attribute__((test)) uint8_t class_ptr_name_test() {
+  assert_true(
+    ERROR,
+    !strcmp(class_name(ptr_class), "ptr"),
+    "Pointer class name error."
+  );
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_ptr_repr_test() {
+  rope_t* repr;
+  char* str1, str2[50];
+
+  for (ptrdiff_t i = 1; i; i *= 2) {
+    repr = class_repr(ptr_class, (void*)i);
+    str1 = rope_str(repr);
+    sprintf(str2, "%p", (void*)i);
+    assert_true(
+      ERROR,
+      !strcmp(str1, str2),
+      "Pointer class repr error."
+    );
+    free(str1);
+    rope_destroy(repr);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_ptr_hash_test() {
+  for (ptrdiff_t i = 1; i; i *= 2) {
+    assert_equal(
+      ERROR,
+      (uint64_t)i,
+      class_hash(ptr_class, (void*)i),
+      "Pointer class hash error."
+    );
+  }
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_ptr_cmp_test() {
+  assert_true(
+    ERROR,
+    class_cmp(ptr_class, (void*)57834, (void*)4657) > 0,
+    "Pointer class cmp error."
+  );
+  assert_true(
+    ERROR,
+    class_cmp(ptr_class, (void*)25646, (void*)757435) < 0,
+    "Pointer class cmp error."
+  );
+  assert_true(
+    ERROR,
+    class_cmp(ptr_class, (void*)453223, (void*)453223) == 0,
+    "Pointer class cmp error."
+  );
+  return EXIT_SUCCESS;
+}

--- a/src/class/test/class_str_test.c
+++ b/src/class/test/class_str_test.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "assert.h"
+#include "class.h"
+
+__attribute__((test)) uint8_t class_str_name_test() {
+  assert_true(
+    ERROR,
+    !strcmp(class_name(str_class), "str"),
+    "String class name error."
+  );
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_str_destroy_test() {
+  char* str = (char*)malloc(sizeof(*str));
+  class_destroy(str_class, str);
+  // Rely on valgrind to verify that memory has been freed
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_str_repr_test() {
+  rope_t* repr;
+  char* dest,  str[] = "This is a test string!";
+
+  repr = class_repr(str_class, str);
+  dest = rope_str(repr);
+  assert_true(
+    ERROR,
+    !strcmp(str, dest),
+    "String class repr error."
+  );
+  free(dest);
+  rope_destroy(repr);
+
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_str_hash_test() {
+  char str1[] = "This is a test string!";
+  char str2[] = "This is b test string!";
+  char str3[] = "This is a test string!";
+  assert_equal(
+    ERROR,
+    class_hash(str_class, str1),
+    class_hash(str_class, str3),
+    "String class hash error."
+  );
+  assert_notequal(
+    ERROR,
+    class_hash(str_class, str1),
+    class_hash(str_class, str2),
+    "String class hash error."
+  );
+  return EXIT_SUCCESS;
+}
+
+__attribute__((test)) uint8_t class_str_cmp_test() {
+  char str1[] = "This is a test string!";
+  char str2[] = "This is b test string!";
+  char str3[] = "This is a test string!";
+  assert_true(
+    ERROR,
+    class_cmp(str_class, str2, str1) > 0,
+    "String class cmp error."
+  );
+  assert_true(
+    ERROR,
+    class_cmp(str_class, str3, str2) < 0,
+    "String class cmp error."
+  );
+  assert_true(
+    ERROR,
+    class_cmp(str_class, str1, str3) == 0,
+    "String class cmp error."
+  );
+  return EXIT_SUCCESS;
+}

--- a/src/global/test/g_line_check.c
+++ b/src/global/test/g_line_check.c
@@ -46,7 +46,7 @@ uint8_t global_line_check(char* filename) {
         }
         free(line);
       }
-      if (col > 80)
+      if (col > 81) // 81 since newline character is included in count
         err |= __assert_fail(
           WARNING,
           "Line too long.",

--- a/src/list/private/l_base.c
+++ b/src/list/private/l_base.c
@@ -134,7 +134,7 @@ uint8_t list_goto(list_t* l, size_t index) {
  *    [EXIT_SUCCESS, ERANGE]
  */
 uint8_t list_at(const list_t* l, list_item_t** item, size_t index) {
-  list_node_internal_t* n = _head.next;
+  __list_node_t* n = _head.next;
   size_t index2 = 0;
   if (index >= _size)
     return ERANGE;
@@ -380,7 +380,7 @@ list_t* list_copy(const list_t* l) {
   );
   if (l2 == NULL)
     return NULL;
-  list_node_internal_t* n = &_head;
+  __list_node_t* n = &_head;
   while ((n = n->next) != &_tail) {
     if (list_append(l2, n->data))
       return NULL;
@@ -396,8 +396,8 @@ list_t* list_copy(const list_t* l) {
  *    [EXIT_SUCCESS]
  */
 uint8_t list_reverse(list_t* l) {
-  list_node_internal_t* n1 = &_head;
-  list_node_internal_t* n2 = &_tail;
+  __list_node_t* n1 = &_head;
+  __list_node_t* n2 = &_tail;
   while (n1 != n2 && n2->next != n1) {
     list_item_t* temp;
     temp = n1->data;
@@ -433,7 +433,7 @@ uint8_t list_unorder(list_t* l) {
  *    [EXIT_SUCCESS, ENOENT]
  */
 uint8_t list_indexof(const list_t* l, size_t* index, const list_item_t* item) {
-  list_node_internal_t* n = &_head;
+  __list_node_t* n = &_head;
   size_t index2 = 0;
   while ((n = n->next) != &_tail) {
     if (__list_item_cmp(l, item, n->data)) {
@@ -475,7 +475,7 @@ int list_cmp(UNUSED const list_t* l, UNUSED const list_t* item) {
  * @return text_t* Text object for this list.
  */
 text_t* list_totext(const list_t* l) {
-  list_node_internal_t* n = &_head;
+  __list_node_t* n = &_head;
   text_t* t = text_create();
   text_t* temp;
   text_append(t, '[');
@@ -521,7 +521,7 @@ uint8_t list_print(const list_t* l) {
  *    [EXIT_SUCCESS, ENOMEM]
  */
 uint8_t __list_node_insert(list_t* l, list_item_t* item) {
-  list_node_internal_t* n = (list_node_internal_t*)malloc(sizeof(*n));
+  __list_node_t* n = (__list_node_t*)malloc(sizeof(*n));
   if (n == NULL)
     return ENOMEM;
   if (_iter == &_head) {
@@ -548,7 +548,7 @@ uint8_t __list_node_insert(list_t* l, list_item_t* item) {
  * @return uint8_t Status code
  *    [EXIT_SUCCESS]
  */
-uint8_t __list_node_delete(list_t* l, list_node_internal_t* n) {
+uint8_t __list_node_delete(list_t* l, __list_node_t* n) {
   n->prev->next = n->next;
   n->next->prev = n->prev;
   _size--;

--- a/src/list/private/l_internal.h
+++ b/src/list/private/l_internal.h
@@ -17,8 +17,8 @@
 #define _reversed (_l->reversed)
 
 typedef void list_item_t;
-struct list_node_struct;
-typedef struct list_node_struct __list_node_t;
+struct List_Node;
+typedef struct List_Node __list_node_t;
 
 uint8_t __list_node_insert(list_t*, list_item_t*);
 uint8_t __list_node_delete(list_t*, __list_node_t*);
@@ -29,13 +29,13 @@ int __list_item_cmp(
 );
 text_t* __ptr_totext(const void*);
 
-struct list_node_struct {
+struct List_Node {
   list_item_t* data;
   __list_node_t* next;
   __list_node_t* prev;
 };
 
-typedef struct {
+typedef struct List {
   size_t size;
   size_t index;
   void (*item_destroy_func)(list_item_t*);

--- a/src/list/private/l_internal.h
+++ b/src/list/private/l_internal.h
@@ -5,7 +5,7 @@
 
 #include "text.h"
 
-#define _l ((list_internal_t*)l)
+#define _l ((__list_t*)l)
 #define _head (_l->head)
 #define _tail (_l->tail)
 #define _iter (_l->iter)
@@ -18,10 +18,10 @@
 
 typedef void list_item_t;
 struct list_node_struct;
-typedef struct list_node_struct list_node_internal_t;
+typedef struct list_node_struct __list_node_t;
 
 uint8_t __list_node_insert(list_t*, list_item_t*);
-uint8_t __list_node_delete(list_t*, list_node_internal_t*);
+uint8_t __list_node_delete(list_t*, __list_node_t*);
 int __list_item_cmp(
   const list_t*,
   const list_item_t*,
@@ -31,8 +31,8 @@ text_t* __ptr_totext(const void*);
 
 struct list_node_struct {
   list_item_t* data;
-  list_node_internal_t* next;
-  list_node_internal_t* prev;
+  __list_node_t* next;
+  __list_node_t* prev;
 };
 
 typedef struct {
@@ -41,10 +41,10 @@ typedef struct {
   void (*item_destroy_func)(list_item_t*);
   int (*item_cmp_func)(const list_item_t*, const list_item_t*);
   text_t* (*item_totext_func)(const list_item_t*);
-  list_node_internal_t head;
-  list_node_internal_t tail;
-  list_node_internal_t* iter;
+  __list_node_t head;
+  __list_node_t tail;
+  __list_node_t* iter;
   bool reversed;
-} list_internal_t;
+} __list_t;
 
 #endif

--- a/src/list/test/list_test.c
+++ b/src/list/test/list_test.c
@@ -1,8 +1,6 @@
-#include <stdio.h>
 #include <time.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <unistd.h>
 
 #include "global.h"
 #include "assert.h"
@@ -518,15 +516,15 @@ __attribute__((test)) uint8_t list_remove_found_ordered_test() {
   );
 
   assert_false(ERROR, list_destroy(l), "List destroy failure.");
-  return EXIT_SUCCESS;
+  return EXIT_SUCCESS; // TODO
 }
 
 __attribute__((test)) uint8_t list_remove_unfound_unordered_test() {
-  return EXIT_SUCCESS;
+  return EXIT_SUCCESS; // TODO
 }
 
 __attribute__((test)) uint8_t list_remove_unfound_ordered_test() {
-  return EXIT_SUCCESS;
+  return EXIT_SUCCESS; // TODO
 }
 
 __attribute__((test)) uint8_t list_purge_uordered_test() {

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,10 @@ int main(int argc, char* argv[]) {
   }
   printf("\n");
 
-  printf("%d\n", strcmp("A", "B"));
+
+  for (int i = 0; i < 2; i++) {
+    printf("%d\n", strcmp("3", "1"));
+  }
 
   return 0;
 }

--- a/src/rope/private/r_base.c
+++ b/src/rope/private/r_base.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "rope.h"
+
+// TODO Implement rope instead of string.
+
+rope_t* rope_create_with(const char* str) {
+  rope_t* r = (rope_t*)malloc(sizeof(*str) * (strlen(str) + 1));
+  strcpy(r, str);
+  return r;
+}
+
+char* rope_str(rope_t* r) {
+  return (char*)r;
+}
+
+void rope_destroy(rope_t*) {
+}

--- a/src/rope/public/rope.h
+++ b/src/rope/public/rope.h
@@ -1,0 +1,10 @@
+#ifndef ROPE_H
+#define ROPE_H
+
+typedef void rope_t;
+
+rope_t* rope_create_with(const char*);
+void rope_destroy(rope_t*);
+char* rope_str(rope_t*);
+
+#endif

--- a/src/text/private/t_base.c
+++ b/src/text/private/t_base.c
@@ -6,7 +6,7 @@
 #include "text.h"
 #include "t_internal.h"
 
-#define _t ((text_internal_t*)t)
+#define _t ((__text_t*)t)
 #define _front (_t->front)
 #define _back (_t->back)
 #define _iter (_t->iter)
@@ -15,7 +15,7 @@
 
 text_t* text_create() {
   text_t* t = (text_t*)malloc(sizeof(*_t));
-  _front = (text_node_internal_t*)malloc(sizeof(*_front));
+  _front = (__text_node_t*)malloc(sizeof(*_front));
   if (_t == NULL || _front == NULL) return NULL;
   _back = _front;
   _front->next = _back;
@@ -89,7 +89,7 @@ bool text_has_next(text_t* t) {
 
 uint8_t text_append(text_t* t, char c) {
   __text_back(t);
-  text_node_internal_t* n = (text_node_internal_t*)malloc(sizeof(*n));
+  __text_node_t* n = (__text_node_t*)malloc(sizeof(*n));
   if (n == NULL) return ENOMEM;
   n->data = c;
   _iter->next = n;
@@ -131,7 +131,7 @@ uint8_t text_delete(text_t* t, size_t index) {
   if (index == 0) err = text_front(t);
   else err = text_goto(t, index - 1);
   if (err) return err;
-  text_node_internal_t* n = _iter->next;
+  __text_node_t* n = _iter->next;
   _iter->next = n->next;
   if (n == _back) _back = _iter;
   free(n);

--- a/src/text/private/t_internal.h
+++ b/src/text/private/t_internal.h
@@ -6,17 +6,17 @@
 
 #include "text.h"
 
-struct text_node_struct;
-typedef struct text_node_struct __text_node_t;
+struct Text_Node;
+typedef struct Text_Node __text_node_t;
 
 uint8_t __text_back(text_t*);
 
-struct text_node_struct {
+struct Text_Node {
   __text_node_t* next;
   char data;
 };
 
-typedef struct {
+typedef struct Text {
   size_t length;
   size_t index;
   __text_node_t* front;

--- a/src/text/private/t_internal.h
+++ b/src/text/private/t_internal.h
@@ -7,21 +7,21 @@
 #include "text.h"
 
 struct text_node_struct;
-typedef struct text_node_struct text_node_internal_t;
+typedef struct text_node_struct __text_node_t;
 
 uint8_t __text_back(text_t*);
 
 struct text_node_struct {
-  text_node_internal_t* next;
+  __text_node_t* next;
   char data;
 };
 
 typedef struct {
   size_t length;
   size_t index;
-  text_node_internal_t* front;
-  text_node_internal_t* back;
-  text_node_internal_t* iter;
-} text_internal_t;
+  __text_node_t* front;
+  __text_node_t* back;
+  __text_node_t* iter;
+} __text_t;
 
 #endif


### PR DESCRIPTION
I had to make the structure for the class public since otherwise classes would have to be allocated on the stack and removed before the program finished. Since this would add extra steps and require certain execution at the end of main, I opted to move the structure to public.

Thankfully, all the fields can be made const so that a constructed class may not be changed. However, it will still be preferable for future development to use the class_* functions instead of the function pointers to interact with any class instance, that way global changes can be made easier.

I didn't want to make a bunch of TODO notes anywhere I avoided implementation of the rope structure, so instead I implemented a a couple basic rope functions instead which, when a true rope implementation comes around, can be replaced.